### PR TITLE
Fix incorrect twitter api call syntax

### DIFF
--- a/app/actors/WebSocketActor.scala
+++ b/app/actors/WebSocketActor.scala
@@ -11,7 +11,7 @@ import services.TwitterProcessor
 
 object WebSocketActor {
   def props(out: ActorRef, tag: String) = Props(new WebSocketActor(out, Global.webSocketCoordinator, tag))
-  val WordFilter = "#inspiringsolutions"
+  val WordFilter = "inspiringsolutions"
 }
 
 class WebSocketActor (out: ActorRef, coordinator: ActorRef, tag: String) extends Actor {


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/5677896/13729088/b7509c18-e92c-11e5-9b54-10cb3312b7eb.png)

![image](https://cloud.githubusercontent.com/assets/5677896/13729090/c834c752-e92c-11e5-86ec-18892deac5ca.png)

This works splendidly